### PR TITLE
Link fixed in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Numpy wrapper for Ruby
 
-This library enables to directry call [numpy](http://pandas.pydata.org/) from Ruby language.
+This library enables to directry call [numpy](https://numpy.org) from Ruby language.
 This uses [pycall](https://github.com/mrkn/pycall.rb).
 
 ## Installation


### PR DESCRIPTION
Link fixed in readme

from http://pandas.pydata.org/ to https://numpy.org